### PR TITLE
Update clang support (#857)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -251,27 +251,6 @@ matrix:
       - make unittest
 
   #
-  # Clang 5.0
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-5.0
-        packages:
-          - gcc-8
-          - g++-8
-          - clang-5.0
-          - nasm
-    env:
-      - TEST="Clang 5.0"
-    script:
-      - export CLANG_BIN=clang-5.0
-      - cmake -DCONFIG=travis_static ..
-      - make -j3
-
-  #
   # Clang 6.0
   #
   - os: linux
@@ -288,9 +267,54 @@ matrix:
     env:
       - TEST="Clang 6.0"
     script:
-      - export CLANG_BIN=clang-6.0
+      - export CLANG_BIN=/usr/bin/clang-6.0
       - cmake -DCONFIG=travis_static ..
       - make -j3
+      - cat depends/newlib/x86_64-vmm-elf/stamp/newlib_x86_64-vmm-elf-build-out.log
+
+  #
+  # Clang 7.0
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-7
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-7
+          - nasm
+    env:
+      - TEST="Clang 7.0"
+    script:
+      - export CLANG_BIN=/usr/bin/clang-7
+      - cmake -DCONFIG=travis_static ..
+      - make -j3
+      - cat depends/newlib/x86_64-vmm-elf/stamp/newlib_x86_64-vmm-elf-build-out.log
+
+  #
+  # Clang 8.0
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-8
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-8
+          - nasm
+    env:
+      - TEST="Clang 8.0"
+    script:
+      - export CLANG_BIN=/usr/bin/clang-8
+      - cmake -DCONFIG=travis_static ..
+      - make -j3
+      - cat depends/newlib/x86_64-vmm-elf/stamp/newlib_x86_64-vmm-elf-build-out.log
 
   #
   # GCC 7

--- a/bfvmm/include/hve/arch/intel_x64/ept/mmap.h
+++ b/bfvmm/include/hve/arch/intel_x64/ept/mmap.h
@@ -1195,8 +1195,8 @@ public:
 
     /// @cond
 
-    mmap(mmap &&) = default;
-    mmap &operator=(mmap &&) = default;
+    mmap(mmap &&) = delete;
+    mmap &operator=(mmap &&) = delete;
 
     mmap(const mmap &) = delete;
     mmap &operator=(const mmap &) = delete;

--- a/bfvmm/include/memory_manager/arch/x64/cr3/mmap.h
+++ b/bfvmm/include/memory_manager/arch/x64/cr3/mmap.h
@@ -1118,8 +1118,8 @@ public:
 
     /// @cond
 
-    mmap(mmap &&) = default;
-    mmap &operator=(mmap &&) = default;
+    mmap(mmap &&) = delete;
+    mmap &operator=(mmap &&) = delete;
 
     mmap(const mmap &) = delete;
     mmap &operator=(const mmap &) = delete;

--- a/scripts/cmake/depends/newlib.cmake
+++ b/scripts/cmake/depends/newlib.cmake
@@ -28,8 +28,13 @@ if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
         URL_MD5     ${NEWLIB_URL_MD5}
     )
 
-    set(CC_FOR_TARGET clang)
-    set(CXX_FOR_TARGET clang)
+    if(DEFINED ENV{CLANG_BIN})
+        set(CC_FOR_TARGET $ENV{CLANG_BIN})
+        set(CXX_FOR_TARGET $ENV{CLANG_BIN})
+    else()
+        set(CC_FOR_TARGET clang)
+        set(CXX_FOR_TARGET clang)
+    endif()
 
     set(AR_FOR_TARGET ar)
     set(AS_FOR_TARGET as)


### PR DESCRIPTION
- Remove clang 5 travis test
- Add clang 7 and 8 travis tests
- Use '= delete' for the mmap move constructors to silence
  the -Wdefaulted-function-deleted warning introduced with clang 8.

Signed-off-by: Connor Davis <davisc@ainfosec.com>